### PR TITLE
swagger-ui /* wildcard conflicts with tree router

### DIFF
--- a/sample/src/sample/service.clj
+++ b/sample/src/sample/service.clj
@@ -215,7 +215,7 @@
        ;["/secure" ^:interceptors [basic-auth] {:delete delete-db}]
 
        ["/doc" {:get [(swagger/swagger-doc)]}]
-       ["/*resource" {:get [(swagger/swagger-ui)]}]]]]))
+       ["/swagger-ui/*resource" {:get [(swagger/swagger-ui)]}]]]]))
 
 (def service {:env :prod
               ::bootstrap/routes routes


### PR DESCRIPTION
Moved the wagger ui wildcard so it doesn't overshadow other routes when using the prefix tree router in 0.4.0. 

Note that requests to /swagger-ui/ fail (rather than redirect to /swagger-ui/index.html) -- appears to be a bug in the prefix tree router that I haven't been able to chase down yet. (Been traveling to Clojure West -- hope to see everyone there :smile: )
