### PR TITLE
Update pedestal to 0.5.1

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -10,17 +10,14 @@
                  [io.pedestal/pedestal.service "0.5.1"]
                  [metosin/ring-swagger "0.22.4"]
                  [metosin/ring-swagger-ui "2.1.4-0"]
-                 [frankiesardo/linked "1.2.2"]]
-  :release-tasks [["vcs" "assert-committed"]
-                  ["change" "version" "leiningen.release/bump-version" "release"]
-                  ["doc"]
-                  ["vcs" "commit"]
-                  ["vcs" "tag" "v"]
-                  ["deploy" "clojars"]
-                  ["rsync" "doc/" "gh-pages"]
-                  ["change" "version" "leiningen.release/bump-version"]
-                  ["vcs" "commit"]
-                  ["vcs" "push"]]
+                 [frankiesardo/linked "1.2.2"]
+                 [s3-wagon-private "1.2.0"]]
+
+  :repositories [["nu-maven" {:url        "s3p://nu-maven/releases/"
+                              :username   [:gpg :env/artifacts_aws_access_key_id]
+                              :passphrase [:gpg :env/artifacts_aws_secret_access_key]}]
+                 ["central" {:url "http://repo1.maven.org/maven2/" :snapshots false}]
+                 ["clojars" {:url "https://clojars.org/repo/"}]]
 
   :profiles {:dev {:dependencies [[io.pedestal/pedestal.jetty "0.5.1"]
                                   [metosin/scjsv "0.2.0" :exclusions [org.clojure/core.async]]]}})

--- a/project.clj
+++ b/project.clj
@@ -8,8 +8,8 @@
           :src-linenum-anchor-prefix "L"}
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [io.pedestal/pedestal.service "0.5.1"]
-                 [metosin/ring-swagger "0.20.4"]
-                 [metosin/ring-swagger-ui "2.1.0"]
+                 [metosin/ring-swagger "0.22.4"]
+                 [metosin/ring-swagger-ui "2.1.4-0"]
                  [frankiesardo/linked "1.2.2"]]
   :release-tasks [["vcs" "assert-committed"]
                   ["change" "version" "leiningen.release/bump-version" "release"]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject frankiesardo/pedestal-swagger "0.4.4-SNAPSHOT"
+(defproject frankiesardo/pedestal-swagger "0.4.4-NUBANK-SNAPSHOT"
   :description "Swagger documentation for Pedestal routes"
   :url "http://github.com/frankiesardo/pedestal-swagger"
   :license {:name "Eclipse Public License"
@@ -6,8 +6,8 @@
   :plugins [[codox "0.8.13"]]
   :codox {:src-dir-uri "http://github.com/frankiesardo/pedestal-swagger/blob/master/"
           :src-linenum-anchor-prefix "L"}
-  :dependencies [[org.clojure/clojure "1.7.0"]
-                 [io.pedestal/pedestal.service "0.4.0"]
+  :dependencies [[org.clojure/clojure "1.8.0"]
+                 [io.pedestal/pedestal.service "0.5.1"]
                  [metosin/ring-swagger "0.20.4"]
                  [metosin/ring-swagger-ui "2.1.0"]
                  [frankiesardo/linked "1.2.2"]]
@@ -22,5 +22,5 @@
                   ["vcs" "commit"]
                   ["vcs" "push"]]
 
-  :profiles {:dev {:dependencies [[io.pedestal/pedestal.jetty "0.4.0"]
+  :profiles {:dev {:dependencies [[io.pedestal/pedestal.jetty "0.5.1"]
                                   [metosin/scjsv "0.2.0" :exclusions [org.clojure/core.async]]]}})

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject frankiesardo/pedestal-swagger "0.4.4-NUBANK-SNAPSHOT"
+(defproject nu-pedestal-swagger "0.4.4-SNAPSHOT"
   :description "Swagger documentation for Pedestal routes"
   :url "http://github.com/frankiesardo/pedestal-swagger"
   :license {:name "Eclipse Public License"

--- a/sample/src/sample/service.clj
+++ b/sample/src/sample/service.clj
@@ -4,7 +4,7 @@
             [pedestal.swagger.error :as sw.error]
             [io.pedestal.http :as bootstrap]
             [io.pedestal.http.route :as route]
-            [io.pedestal.impl.interceptor :refer [terminate]]
+            [io.pedestal.interceptor.chain :refer [terminate]]
             [io.pedestal.interceptor.helpers :as interceptor]
             [ring.util.http-response :as resp]
             [ring.util.http-status :as status]

--- a/src/pedestal/swagger/core.clj
+++ b/src/pedestal/swagger/core.clj
@@ -3,7 +3,7 @@
             [pedestal.swagger.schema :as schema]
             [pedestal.swagger.body-params :as body-params]
             [schema.core :as s]
-            [io.pedestal.http.route.definition :refer [expand-routes]]
+            [io.pedestal.http.route :refer [expand-routes]]
             [io.pedestal.interceptor.helpers :as interceptor]
             [io.pedestal.interceptor :as i]
             [ring.util.response :refer [response resource-response redirect]]

--- a/src/pedestal/swagger/schema.clj
+++ b/src/pedestal/swagger/schema.clj
@@ -2,7 +2,7 @@
   (:require [schema.coerce :as c]
             [schema.core :as s]
             [schema.utils :as u]
-            [io.pedestal.impl.interceptor :refer [terminate]]))
+            [io.pedestal.interceptor.chain :refer [terminate]]))
 
 (defn- coerce! [schema value coercions]
   (let [result ((c/coercer schema coercions) value)]

--- a/test/pedestal/swagger/core_test.clj
+++ b/test/pedestal/swagger/core_test.clj
@@ -121,7 +121,7 @@
     (is (= paths (doc/gen-paths routes)))))
 
 (deftest generates-valid-json-schema
-  (let [validator (v/validator (slurp (io/resource "ring/swagger/v2.0_schema.json")))]
+  (let [validator (v/validator (slurp (io/resource "ring/swagger/swagger-schema.json")))]
     (validator (spec/swagger-json {:paths (doc/gen-paths routes)}))))
 
 (deftest coerces-params


### PR DESCRIPTION
Also bumping transitive dependencies (on ring-swagger and ring-swagger-ui) to avoid downstream users having to override them.